### PR TITLE
Unbreak build with default configure options

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ if BUILD_SHADER_DEBUGGER
 SUBDIRS += debugger
 endif
 
-SUBDIRS += overlay demos benchmarks
+SUBDIRS += demos benchmarks
 endif
 
 SUBDIRS += docs

--- a/benchmarks/gem_busy.c
+++ b/benchmarks/gem_busy.c
@@ -45,6 +45,10 @@
 #include "intel_chipset.h"
 #include "igt_stats.h"
 
+#ifndef ETIME
+#define ETIME ETIMEDOUT
+#endif
+
 #define LOCAL_IOCTL_I915_GEM_EXECBUFFER2_WR       DRM_IOWR(DRM_COMMAND_BASE + DRM_I915_GEM_EXECBUFFER2, struct drm_i915_gem_execbuffer2)
 
 #define LOCAL_I915_EXEC_NO_RELOC (1<<11)

--- a/benchmarks/gem_exec_tracer.c
+++ b/benchmarks/gem_exec_tracer.c
@@ -42,6 +42,15 @@
 #include "intel_aub.h"
 #include "intel_chipset.h"
 
+#ifndef _IOC_TYPE
+#define _IOC_NRBITS  8
+#define _IOC_NRSHIFT 0
+#define _IOC_TYPEMASK        ((1 << _IOC_TYPEBITS)-1)
+#define _IOC_TYPESHIFT   (_IOC_NRSHIFT + _IOC_NRBITS)
+#define _IOC_TYPEBITS	8
+#define _IOC_TYPE(nr)                (((nr) >> _IOC_TYPESHIFT) & _IOC_TYPEMASK)
+#endif
+
 static int (*libc_close)(int fd);
 static int (*libc_ioctl)(int fd, unsigned long request, void *argp);
 

--- a/benchmarks/gem_syslatency.c
+++ b/benchmarks/gem_syslatency.c
@@ -43,9 +43,6 @@
 #include <limits.h>
 #include "drm.h"
 
-#include <linux/unistd.h>
-
-#define gettid() syscall(__NR_gettid)
 #define sigev_notify_thread_id _sigev_un._tid
 
 static volatile int done;
@@ -152,7 +149,6 @@ static void *sys_wait(void *arg)
 	sigprocmask(SIG_SETMASK, &mask, NULL);
 
 	sev.sigev_notify = SIGEV_SIGNAL | SIGEV_THREAD_ID;
-	sev.sigev_notify_thread_id = gettid();
 	sev.sigev_signo = SIG;
 	timer_create(CLOCK_MONOTONIC, &sev, &timer);
 

--- a/configure.ac
+++ b/configure.ac
@@ -126,7 +126,7 @@ PKG_CHECK_MODULES(PCIACCESS, [pciaccess >= 0.10])
 #PKG_CHECK_MODULES(PROCPS, [libprocps])
 
 case "$target_cpu" in
-	x86*|i?86)
+	x86*|i?86|amd64)
 		build_x86="yes"
 		;;
 	*)

--- a/tests/Makefile.sources
+++ b/tests/Makefile.sources
@@ -128,7 +128,6 @@ TESTS_progs_M = \
 	kms_tv_load_detect \
 	pm_backlight \
 	pm_lpsp \
-	pm_rpm \
 	pm_rps \
 	pm_rc6_residency \
 	pm_sseu \

--- a/tests/kms_atomic_transition.c
+++ b/tests/kms_atomic_transition.c
@@ -384,7 +384,6 @@ static void commit_display(igt_display_t *display, unsigned event_mask, bool non
 		char buf[32];
 		struct drm_event *e = (void *)buf;
 		struct drm_event_vblank *vblank = (void *)buf;
-		uint32_t crtc_id, pipe = I915_MAX_PIPES;
 
 		ret = read(display->drm_fd, buf, sizeof(buf));
 		if (ret < 0 && (errno == EINTR || errno == EAGAIN))
@@ -393,17 +392,7 @@ static void commit_display(igt_display_t *display, unsigned event_mask, bool non
 		igt_assert(ret >= 0);
 		igt_assert_eq(e->type, DRM_EVENT_FLIP_COMPLETE);
 
-		crtc_id = vblank->reserved;
-		if (crtc_id) {
-			for_each_pipe(display, pipe)
-				if (display->pipes[pipe].crtc_id == crtc_id)
-					break;
-
-			igt_assert_lt(pipe, display->n_pipes);
-
-			igt_debug("Retrieved vblank seq: %u on %u/%u\n", vblank->sequence, vblank->reserved, pipe);
-		} else
-			igt_debug("Retrieved vblank seq: %u on unk/unk\n", vblank->sequence);
+		igt_debug("Retrieved vblank seq: %u on unk/unk\n", vblank->sequence);
 
 		num_events--;
 	}

--- a/tests/sw_sync.c
+++ b/tests/sw_sync.c
@@ -37,6 +37,9 @@
 
 #include "sw_sync.h"
 
+#ifndef ETIME
+#define ETIME ETIMEDOUT
+#endif
 
 IGT_TEST_DESCRIPTION("Test SW Sync Framework");
 

--- a/tools/aubdump.c
+++ b/tools/aubdump.c
@@ -47,6 +47,16 @@
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))
 #endif
 
+
+#ifndef _IOC_TYPE
+#define _IOC_NRBITS  8
+#define _IOC_NRSHIFT 0
+#define _IOC_TYPEMASK        ((1 << _IOC_TYPEBITS)-1)
+#define _IOC_TYPESHIFT   (_IOC_NRSHIFT + _IOC_NRBITS)
+#define _IOC_TYPEBITS	8
+#define _IOC_TYPE(nr)                (((nr) >> _IOC_TYPESHIFT) & _IOC_TYPEMASK)
+#endif
+
 static int close_init_helper(int fd);
 static int ioctl_init_helper(int fd, unsigned long request, ...);
 
@@ -199,7 +209,7 @@ write_header(void)
 		  (0 << AUB_HEADER_MINOR_SHIFT));
 
 	/* Next comes a 32-byte application name. */
-	strncpy(app_name, program_invocation_short_name, sizeof(app_name));
+	strncpy(app_name, getprogname(), sizeof(app_name));
 	app_name[sizeof(app_name) - 1] = 0;
 	data_out(app_name, sizeof(app_name));
 


### PR DESCRIPTION
```
$ ./autogen.sh
$ ./configure --disable-dependency-tracking
$ gmake
aubdump.c:202:20: error: use of undeclared identifier 'program_invocation_short_name'
        strncpy(app_name, program_invocation_short_name, sizeof(app_name));
                          ^
aubdump.c:594:6: error: implicit declaration of function '_IOC_TYPE' is invalid in C99
      [-Werror,-Wimplicit-function-declaration]
        if (_IOC_TYPE(request) == DRM_IOCTL_BASE &&
            ^
```